### PR TITLE
ghq + peco を使ってディレクトリ移動できるようにする

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -21,3 +21,10 @@ source ~/perl5/perlbrew/etc/bashrc
 export PATH="/usr/local/heroku/bin:$PATH"
 
 export GOPATH=$HOME
+
+# ghq + peco
+function ghq-peco () {
+  selected_dir=$(ghq list -p | peco)
+  [ -n "$selected_dir" ] && cd $selected_dir
+}
+bind '"\C-]":"ghq-peco\n"'


### PR DESCRIPTION
### やりたいこと
- よくみかける、ghq + peco を使ってディレクトリ移動したい
- `cd $(ghq list -p | peco)`を実行すれば可能だが、ショートカットキーを使いたい
- よく zsh スクリプトのサンプルを見かけるけど、bash を使いたい
- そのスクリプトの中身を理解したい
### このプルリクエストをマージすると

何らかのショートカットキーでやりたいことが実行できるようになります
### 参考情報
- http://weblog.bulknews.net/post/89635306479/ghq-peco-percol
- http://mattn.kaoriya.net/software/peco.htm
### リファレンス
- [The Z Shell Manual](http://zsh.sourceforge.net/Doc/Release/zsh.html)
- [Bash Reference Manual](http://www.gnu.org/software/bash/manual/html_node/index.html)
