### PR TITLE
Symlink to MacVim-Kaoriya

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Force mode
 $ ~/.dotfiles/install.rb --do-it --force
 ```
 
+### Install MacVim-Kaoriya
+
+https://code.google.com/p/macvim-kaoriya/
+
+After install, create symlinks.
+
+```
+$ ~/.dotfiles/install.rb --do-it
+```
+
+日本語文字コード自動判別とか便利なのでこれ使ってるけど、ほんとは homebrew でサクッと入れてシンボリックリンクも作ってもらいたい
+
 ### Setup
 
 ```

--- a/install.rb
+++ b/install.rb
@@ -37,10 +37,14 @@ class DotfileInstaller
   end
 
   def symlink_to_home(resource)
-    options = '-s'
-
     target = File.expand_path("~/.#{resource}")
     source = File.expand_path("~/.dotfiles/#{resource}")
+
+    symlink source target
+  end
+
+  def symlink(source target)
+    options = '-s'
 
     if File.exists?(target)
       if @force

--- a/install.rb
+++ b/install.rb
@@ -23,14 +23,18 @@ class DotfileInstaller
   end
 
   def execute
+    setup_dotfiles
+  end
+
+  private
+
+  def setup_dotfiles
     %w(
       vim bash_profile bashrc gitignore gvimrc hgrc screenrc vimrc
     ).each do |resource|
       copy resource
     end
   end
-
-  private
 
   def copy(resource)
     options = '-s'

--- a/install.rb
+++ b/install.rb
@@ -23,10 +23,29 @@ class DotfileInstaller
   end
 
   def execute
+    setup_macvim_kaoriya
     setup_dotfiles
   end
 
   private
+
+  def setup_macvim_kaoriya
+    # MEMO: ふつうの MacVim なら brew install macvim --override-system-vim でよいが Kaoriya 版なので自前でやる
+    # TODO: Kaoriya を判定する方法？
+    macvim_bin_dir = '/Applications/MacVim.app/Contents/MacOS'
+    binaries       = %w(Vim mvim mview mvimdiff view vimdiff)
+
+    if Dir.exists? macvim_bin_dir
+      binaries.each do |binary|
+        target = "/usr/local/bin/#{binary.downcase}"
+        source = macvim_bin_dir + '/' + binary
+
+        symlink source target
+      end
+    else
+      puts "MacVim-Kaoriya is not installed."
+    end
+  end
 
   def setup_dotfiles
     %w(

--- a/install.rb
+++ b/install.rb
@@ -37,10 +37,12 @@ class DotfileInstaller
     if Dir.exists? macvim_bin_dir
       binaries.each do |binary|
         target = "/usr/local/bin/#{binary.downcase}"
-        source = macvim_bin_dir + '/' + binary
+        source = "#{macvim_bin_dir}/#{binary}"
 
         symlink source, target
       end
+
+      symlink '/usr/local/bin/vim', '/usr/local/bin/vi'
     else
       puts "MacVim-Kaoriya is not installed."
     end

--- a/install.rb
+++ b/install.rb
@@ -30,8 +30,7 @@ class DotfileInstaller
   private
 
   def setup_macvim_kaoriya
-    # MEMO: ふつうの MacVim なら brew install macvim --override-system-vim でよいが Kaoriya 版なので自前でやる
-    # TODO: Kaoriya を判定する方法？
+    # ふつうの MacVim なら brew install macvim --override-system-vim でよいが Kaoriya 版なので自前でやる
     macvim_bin_dir = '/Applications/MacVim.app/Contents/MacOS'
     binaries       = %w(Vim mvim mview mvimdiff view vimdiff)
 

--- a/install.rb
+++ b/install.rb
@@ -32,11 +32,11 @@ class DotfileInstaller
     %w(
       vim bash_profile bashrc gitignore gvimrc hgrc screenrc vimrc
     ).each do |resource|
-      copy resource
+      symlink_to_home resource
     end
   end
 
-  def copy(resource)
+  def symlink_to_home(resource)
     options = '-s'
 
     target = File.expand_path("~/.#{resource}")

--- a/install.rb
+++ b/install.rb
@@ -40,7 +40,7 @@ class DotfileInstaller
         target = "/usr/local/bin/#{binary.downcase}"
         source = macvim_bin_dir + '/' + binary
 
-        symlink source target
+        symlink source, target
       end
     else
       puts "MacVim-Kaoriya is not installed."
@@ -59,10 +59,10 @@ class DotfileInstaller
     target = File.expand_path("~/.#{resource}")
     source = File.expand_path("~/.dotfiles/#{resource}")
 
-    symlink source target
+    symlink source, target
   end
 
-  def symlink(source target)
+  def symlink(source, target)
     options = '-s'
 
     if File.exists?(target)


### PR DESCRIPTION
### やりたいこと

ふつうの MacVim を homebrew でインストールするとき、

```
brew install macvim --override-system-vim
```

とすると、`/usr/local/bin`からシンボリックリンクを張ってくれる。
Kaoriya 版だとできなそうなので、とりあえず自前でやる。
### 課題

Kaoriya 版のインストールも含めてもっといいやり方が求められる
